### PR TITLE
Skmono/bytearray bignumber conversion

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,9 +9,9 @@ import sys
 import platform
 import subprocess
 
-from distutils.version import LooseVersion
 from setuptools import setup, find_packages, Extension
 from setuptools.command.build_ext import build_ext
+from distutils.version import LooseVersion
 
 
 class CMakeExtension(Extension):

--- a/src/ipcl_python/bindings/include/ipcl_bindings.h
+++ b/src/ipcl_python/bindings/include/ipcl_bindings.h
@@ -32,11 +32,10 @@ void def_ipclPlainText(pybind11::module&);
 void def_ipclCipherText(pybind11::module&);
 
 namespace ipclPythonUtils {
-std::pair<int, pybind11::list> BN2pylist(const BigNumber& bn);
-BigNumber pylist2BN(const pybind11::list& l_bn);
-BigNumber pylist2BN(int length, const pybind11::list& l_bn);
 pybind11::tuple getTupleIpclPubKey(const ipcl::PublicKey* pk);
 ipcl::PublicKey* setIpclPubKey(const pybind11::tuple& t_pk);
+BigNumber pyByte2BN(const pybind11::bytes& data);
+pybind11::bytes BN2bytes(const BigNumber& bn);
 };  // namespace ipclPythonUtils
 
 #endif  // SRC_IPCL_PYTHON_BINDINGS_INCLUDE_IPCL_BINDINGS_H_

--- a/src/ipcl_python/bindings/include/ipcl_bindings.h
+++ b/src/ipcl_python/bindings/include/ipcl_bindings.h
@@ -35,7 +35,6 @@ namespace ipclPythonUtils {
 pybind11::tuple getTupleIpclPubKey(const ipcl::PublicKey* pk);
 ipcl::PublicKey* setIpclPubKey(const pybind11::tuple& t_pk);
 BigNumber pyByte2BN(const pybind11::bytes& data);
-// BigNumber pyByte2BN(pybind11::bytes data);
 pybind11::bytes BN2bytes(const BigNumber& bn);
 };  // namespace ipclPythonUtils
 

--- a/src/ipcl_python/bindings/include/ipcl_bindings.h
+++ b/src/ipcl_python/bindings/include/ipcl_bindings.h
@@ -35,6 +35,7 @@ namespace ipclPythonUtils {
 pybind11::tuple getTupleIpclPubKey(const ipcl::PublicKey* pk);
 ipcl::PublicKey* setIpclPubKey(const pybind11::tuple& t_pk);
 BigNumber pyByte2BN(const pybind11::bytes& data);
+// BigNumber pyByte2BN(pybind11::bytes data);
 pybind11::bytes BN2bytes(const BigNumber& bn);
 };  // namespace ipclPythonUtils
 

--- a/src/ipcl_python/bindings/ipcl_bindings.cpp
+++ b/src/ipcl_python/bindings/ipcl_bindings.cpp
@@ -66,14 +66,27 @@ ipcl::PublicKey* setIpclPubKey(const py::tuple& t_pk) {
 }
 
 BigNumber pyByte2BN(const py::bytes& data) {
+  // BigNumber pyByte2BN(py::bytes data) {
   py::buffer_info buffer_info(py::buffer(data).request());
-  const unsigned char* chardata =
-      reinterpret_cast<const unsigned char*>(buffer_info.ptr);
-  size_t length = static_cast<size_t>(buffer_info.size);
+  // const unsigned char* chardata =
+  //     reinterpret_cast<const unsigned char*>(buffer_info.ptr);
 
-  const Ipp32u* data32 = reinterpret_cast<const Ipp32u*>(chardata);
-  size_t new_length = (length + 3) / 4;
-  BigNumber bn(data32, new_length);
+  const Ipp32u* data32 = reinterpret_cast<const Ipp32u*>(buffer_info.ptr);
+
+  size_t length = (static_cast<size_t>(buffer_info.size) + 3) >> 2;
+
+  std::vector<Ipp32u> newvec(data32, data32 + length);
+  // std::cout<<"unsigned char array"<<std::endl;
+  // for(size_t i=0; i<length; i++)
+  //   std::cout<<i<<":"<<chardata[i]<<":"<<std::endl;
+  // size_t new_length = (length+3) >> 2;//(length + 3) / 4;
+
+  std::cout << "cast to uint32 array" << std::endl;
+  for (size_t i = 0; i < length; i++)
+    std::cout << i << ":" << newvec[i] << std::endl;
+
+  BigNumber bn(newvec.data(), newvec.size());
+
   return bn;
 }
 

--- a/src/ipcl_python/bindings/ipcl_bindings_classes.cpp
+++ b/src/ipcl_python/bindings/ipcl_bindings_classes.cpp
@@ -409,17 +409,16 @@ void def_BigNumber(py::module& m) {
            "ipclBigNumber constructor with array of integers - little endian "
            "format")
       .def(py::init([](const py::bytes& data) {
-        const py::bytes newdata = data;
-        return ipclPythonUtils::pyByte2BN(newdata);
-        // return std::unique_ptr<BigNumber>(
-        //     new BigNumber(ipclPythonUtils::pyByte2BN(data)));
+        // return ipclPythonUtils::pyByte2BN(data);
+        return std::unique_ptr<BigNumber>(
+            new BigNumber(ipclPythonUtils::pyByte2BN(data)));
       }))
-      .def(py::init([](const py::bytearray& data) {
-        const py::bytes newdata = data;
-        return ipclPythonUtils::pyByte2BN(newdata);
-        // return std::unique_ptr<BigNumber>(
-        //     new BigNumber(ipclPythonUtils::pyByte2BN(data)));
-      }))
+      // .def(py::init([](const py::bytearray& data) {
+      //   const py::bytes newdata = data;
+      //   return ipclPythonUtils::pyByte2BN(newdata);
+      //   // return std::unique_ptr<BigNumber>(
+      //   //     new BigNumber(ipclPythonUtils::pyByte2BN(data)));
+      // }))
       .def("__repr__",
            [](BigNumber const& self) {
              std::stringstream ss_hash;

--- a/src/ipcl_python/bindings/ipcl_bindings_classes.cpp
+++ b/src/ipcl_python/bindings/ipcl_bindings_classes.cpp
@@ -409,8 +409,16 @@ void def_BigNumber(py::module& m) {
            "ipclBigNumber constructor with array of integers - little endian "
            "format")
       .def(py::init([](const py::bytes& data) {
-        return std::unique_ptr<BigNumber>(
-            new BigNumber(ipclPythonUtils::pyByte2BN(data)));
+        const py::bytes newdata = data;
+        return ipclPythonUtils::pyByte2BN(newdata);
+        // return std::unique_ptr<BigNumber>(
+        //     new BigNumber(ipclPythonUtils::pyByte2BN(data)));
+      }))
+      .def(py::init([](const py::bytearray& data) {
+        const py::bytes newdata = data;
+        return ipclPythonUtils::pyByte2BN(newdata);
+        // return std::unique_ptr<BigNumber>(
+        //     new BigNumber(ipclPythonUtils::pyByte2BN(data)));
       }))
       .def("__repr__",
            [](BigNumber const& self) {

--- a/src/ipcl_python/bindings/ipcl_bindings_classes.cpp
+++ b/src/ipcl_python/bindings/ipcl_bindings_classes.cpp
@@ -413,12 +413,6 @@ void def_BigNumber(py::module& m) {
         return std::unique_ptr<BigNumber>(
             new BigNumber(ipclPythonUtils::pyByte2BN(data)));
       }))
-      // .def(py::init([](const py::bytearray& data) {
-      //   const py::bytes newdata = data;
-      //   return ipclPythonUtils::pyByte2BN(newdata);
-      //   // return std::unique_ptr<BigNumber>(
-      //   //     new BigNumber(ipclPythonUtils::pyByte2BN(data)));
-      // }))
       .def("__repr__",
            [](BigNumber const& self) {
              std::stringstream ss_hash;

--- a/src/ipcl_python/ipcl_python.py
+++ b/src/ipcl_python/ipcl_python.py
@@ -776,6 +776,18 @@ class PaillierEncryptedNumber(object):
 class BNUtils:
     # slice first then send array
     @staticmethod
+    def int2Bytes(val: int) -> bytes:
+        val_bytes = val.to_bytes(
+            (val.bit_length() + 7) // 8, byteorder="little"
+        )
+        return val_bytes
+
+    @staticmethod
+    def bytes2Int(val: bytes) -> int:
+        val_int = int.from_bytes(val, "little")
+        return val_int
+
+    @staticmethod
     def int2BN(val: int) -> ipclBigNumber:
         """
         Convert Python integer to BigNumber
@@ -786,6 +798,7 @@ class BNUtils:
         Returns:
             BigNumber representation of val
         """
+
         if val == 0:
             return ipclBigNumber.Zero
         elif val == 1:
@@ -793,11 +806,7 @@ class BNUtils:
         elif val == 2:
             return ipclBigNumber.Two
 
-        ret = []
-        while val > 0:
-            ret.append(val & (0xFFFFFFFF))
-            val = val >> 32
-        ret_bn = ipclBigNumber(ret)
+        ret_bn = ipclBigNumber(BNUtils.int2Bytes(val))
 
         return ret_bn
 
@@ -812,8 +821,5 @@ class BNUtils:
         Returns:
             Python integer representation of BigNumber
         """
-        ret = 0
-        sz, arr = val.data()
-        for i in reversed(range(sz)):
-            ret += arr[i] << (32 * i)
+        ret = BNUtils.bytes2Int(val.to_bytes())
         return ret

--- a/src/ipcl_python/ipcl_python.py
+++ b/src/ipcl_python/ipcl_python.py
@@ -136,6 +136,20 @@ class PaillierPublicKey(object):
             encoding = FixedPointNumber.encode(val, self.n, self.max_int)
             enc.append(BNUtils.int2BN(encoding.encoding))
             expo.append(encoding.exponent)
+        # print(enc, expo)
+
+        # tmp = []
+        # for pt, _expo in zip(enc, expo):
+        #     dec = FixedPointNumber(
+        #         BNUtils.BN2int(pt),
+        #         _expo,
+        #         self.n,
+        #         self.max_int,
+        #     )
+        #     tmp.append(dec.decode())
+
+        # print(tmp)
+
         plaintext = ipclPlainText(enc)
         ct = self.pubkey.encrypt(plaintext, apply_obfuscator)
         return PaillierEncryptedNumber(
@@ -447,8 +461,10 @@ class PaillierEncryptedNumber(object):
                 for _ct, _expo in zip(self.ciphertextBN(), self.exponent()):
                     neg_ct.append(
                         BNUtils.int2BN(
-                            gmpy2.invert(
-                                BNUtils.BN2int(_ct), self.public_key.nsquare
+                            int(
+                                gmpy2.invert(
+                                    BNUtils.BN2int(_ct), self.public_key.nsquare
+                                )
                             )
                         )
                     )
@@ -500,8 +516,10 @@ class PaillierEncryptedNumber(object):
                     this_pt.append(BNUtils.int2BN(self.public_key.n - pt))
                     this_ct.append(
                         BNUtils.int2BN(
-                            gmpy2.invert(
-                                BNUtils.BN2int(_ct), self.public_key.nsquare
+                            int(
+                                gmpy2.invert(
+                                    BNUtils.BN2int(_ct), self.public_key.nsquare
+                                )
                             )
                         )
                     )
@@ -680,7 +698,7 @@ class PaillierEncryptedNumber(object):
                 if _x_expo > _y_expo:
                     y_factor.append(
                         BNUtils.int2BN(
-                            pow(FixedPointNumber.BASE, _x_expo - _y_expo)
+                            int(pow(FixedPointNumber.BASE, _x_expo - _y_expo))
                         )
                     )
                     y_factor_exponent.append(_x_expo - _y_expo)
@@ -691,7 +709,7 @@ class PaillierEncryptedNumber(object):
                 elif _x_expo < _y_expo:
                     x_factor.append(
                         BNUtils.int2BN(
-                            pow(FixedPointNumber.BASE, _y_expo - _x_expo)
+                            int(pow(FixedPointNumber.BASE, _y_expo - _x_expo))
                         )
                     )
                     x_factor_exponent.append(_y_expo - _x_expo)
@@ -806,7 +824,16 @@ class BNUtils:
         elif val == 2:
             return ipclBigNumber.Two
 
-        ret_bn = ipclBigNumber(BNUtils.int2Bytes(val))
+        print("Python val - ", val)
+        val_bytes = BNUtils.int2Bytes(val)
+        ret_bn = ipclBigNumber(val_bytes)
+        # verify
+        tmp = BNUtils.BN2int(ret_bn)
+        if val != tmp:
+            print("mismatch!!!")
+            print(val, val_bytes)
+            print(ret_bn, tmp)
+            raise ValueError("int2BN mismatch")
 
         return ret_bn
 

--- a/src/ipcl_python/ipcl_python.py
+++ b/src/ipcl_python/ipcl_python.py
@@ -136,19 +136,6 @@ class PaillierPublicKey(object):
             encoding = FixedPointNumber.encode(val, self.n, self.max_int)
             enc.append(BNUtils.int2BN(encoding.encoding))
             expo.append(encoding.exponent)
-        # print(enc, expo)
-
-        # tmp = []
-        # for pt, _expo in zip(enc, expo):
-        #     dec = FixedPointNumber(
-        #         BNUtils.BN2int(pt),
-        #         _expo,
-        #         self.n,
-        #         self.max_int,
-        #     )
-        #     tmp.append(dec.decode())
-
-        # print(tmp)
 
         plaintext = ipclPlainText(enc)
         ct = self.pubkey.encrypt(plaintext, apply_obfuscator)
@@ -824,17 +811,8 @@ class BNUtils:
         elif val == 2:
             return ipclBigNumber.Two
 
-        print("Python val - ", val)
         val_bytes = BNUtils.int2Bytes(val)
         ret_bn = ipclBigNumber(val_bytes)
-        # verify
-        tmp = BNUtils.BN2int(ret_bn)
-        if val != tmp:
-            print("mismatch!!!")
-            print(val, val_bytes)
-            print(ret_bn, tmp)
-            raise ValueError("int2BN mismatch")
-
         return ret_bn
 
     @staticmethod


### PR DESCRIPTION
Optimize data conversion between Python integer and IPCL BigNumber
int->BigNumber: 2.2x
BigNumber->int: 7.1x

Overall improves performance including serialization - deserialization