### PR TITLE
Fix build issue (#28) when using Python3.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ g++ >= 7.0 or clang >= 10.0
 
 The following libraries and tools are also required,
 ```
-python >= 3.6.9
+Python >= 3.8
 pip >= 22.0.1
 OpenSSL >= 1.1.0
 numa >= 2.0.12

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,6 @@
 wheel
 numpy==1.23.1
 pycryptodomex==3.15.0
-gmpy2==2.0.8
+gmpy2==2.1.5
 cachetools==3.0.0
 ruamel-yaml==0.16.10

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ setup(
         "wheel",
         "numpy==1.23.1",
         "pycryptodomex==3.15.0",
-        "gmpy2==2.0.8",
+        "gmpy2==2.1.5",
         "cachetools==3.0.0",
         "ruamel.yaml==0.16.10",
     ],


### PR DESCRIPTION
Fix https://github.com/intel/pailliercryptolib_python/issues/28 and update Python version requirement.