### PR TITLE
Fix issue (#29) by enabling precision when encrypting

### DIFF
--- a/src/ipcl_python/ipcl_python.py
+++ b/src/ipcl_python/ipcl_python.py
@@ -135,7 +135,8 @@ class PaillierPublicKey(object):
                     "PaillierPublicKey.encrypt: input value(s) should be"
                     " integer or float"
                 )
-            encoding = FixedPointNumber.encode(val, self.n, self.max_int, precision)
+            encoding = FixedPointNumber.encode(
+                val, self.n, self.max_int, precision)
             enc.append(BNUtils.int2BN(encoding.encoding))
             expo.append(encoding.exponent)
 
@@ -295,7 +296,8 @@ class PaillierEncryptedNumber(object):
             ciphertextPyInt,
         ) = state
         self.__ipclCipherText = ipclCipherText(
-            self.public_key.pubkey, [BNUtils.int2BN(i) for i in ciphertextPyInt]
+            self.public_key.pubkey, [
+                BNUtils.int2BN(i) for i in ciphertextPyInt]
         )
 
     def __len__(self) -> int:
@@ -456,7 +458,8 @@ class PaillierEncryptedNumber(object):
                         BNUtils.int2BN(
                             int(
                                 gmpy2.invert(
-                                    BNUtils.BN2int(_ct), self.public_key.nsquare
+                                    BNUtils.BN2int(
+                                        _ct), self.public_key.nsquare
                                 )
                             )
                         )
@@ -511,7 +514,8 @@ class PaillierEncryptedNumber(object):
                         BNUtils.int2BN(
                             int(
                                 gmpy2.invert(
-                                    BNUtils.BN2int(_ct), self.public_key.nsquare
+                                    BNUtils.BN2int(
+                                        _ct), self.public_key.nsquare
                                 )
                             )
                         )

--- a/src/ipcl_python/ipcl_python.py
+++ b/src/ipcl_python/ipcl_python.py
@@ -296,8 +296,7 @@ class PaillierEncryptedNumber(object):
             ciphertextPyInt,
         ) = state
         self.__ipclCipherText = ipclCipherText(
-            self.public_key.pubkey, [
-                BNUtils.int2BN(i) for i in ciphertextPyInt]
+            self.public_key.pubkey, [BNUtils.int2BN(i) for i in ciphertextPyInt]
         )
 
     def __len__(self) -> int:
@@ -458,8 +457,7 @@ class PaillierEncryptedNumber(object):
                         BNUtils.int2BN(
                             int(
                                 gmpy2.invert(
-                                    BNUtils.BN2int(
-                                        _ct), self.public_key.nsquare
+                                    BNUtils.BN2int(_ct), self.public_key.nsquare
                                 )
                             )
                         )
@@ -514,8 +512,7 @@ class PaillierEncryptedNumber(object):
                         BNUtils.int2BN(
                             int(
                                 gmpy2.invert(
-                                    BNUtils.BN2int(
-                                        _ct), self.public_key.nsquare
+                                    BNUtils.BN2int(_ct), self.public_key.nsquare
                                 )
                             )
                         )

--- a/src/ipcl_python/ipcl_python.py
+++ b/src/ipcl_python/ipcl_python.py
@@ -112,7 +112,7 @@ class PaillierPublicKey(object):
         self,
         value: Union[np.ndarray, list, int, float],
         apply_obfuscator: bool = True,
-        precision: Union[None, int] = None
+        precision: Union[None, int] = None,
     ) -> "PaillierEncryptedNumber":
         """
         Encrypts scalar or list/array of scalars

--- a/src/ipcl_python/ipcl_python.py
+++ b/src/ipcl_python/ipcl_python.py
@@ -112,6 +112,7 @@ class PaillierPublicKey(object):
         self,
         value: Union[np.ndarray, list, int, float],
         apply_obfuscator: bool = True,
+        precision: Union[None, int] = None
     ) -> "PaillierEncryptedNumber":
         """
         Encrypts scalar or list/array of scalars
@@ -134,7 +135,7 @@ class PaillierPublicKey(object):
                     "PaillierPublicKey.encrypt: input value(s) should be"
                     " integer or float"
                 )
-            encoding = FixedPointNumber.encode(val, self.n, self.max_int)
+            encoding = FixedPointNumber.encode(val, self.n, self.max_int, precision)
             enc.append(BNUtils.int2BN(encoding.encoding))
             expo.append(encoding.exponent)
 

--- a/src/ipcl_python/ipcl_python.py
+++ b/src/ipcl_python/ipcl_python.py
@@ -136,7 +136,8 @@ class PaillierPublicKey(object):
                     " integer or float"
                 )
             encoding = FixedPointNumber.encode(
-                val, self.n, self.max_int, precision)
+                val, self.n, self.max_int, precision
+            )
             enc.append(BNUtils.int2BN(encoding.encoding))
             expo.append(encoding.exponent)
 


### PR DESCRIPTION
Default precision leads to loss of accuracy sometimes. Enable setting precision (scale factor) manually. 

Fix https://github.com/intel/pailliercryptolib_python/issues/29. 